### PR TITLE
Update deps to run on python 3.8.6

### DIFF
--- a/conduit/urls.py
+++ b/conduit/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
 
-    url(r'^api/', include('conduit.apps.articles.urls', namespace='articles')),
-    url(r'^api/', include('conduit.apps.authentication.urls', namespace='authentication')),
-    url(r'^api/', include('conduit.apps.profiles.urls', namespace='profiles')),
+    url(r'^api/', include(('conduit.apps.articles.urls', 'articles'), namespace='articles')),
+    url(r'^api/', include(('conduit.apps.authentication.urls', 'authentication'), namespace='authentication')),
+    url(r'^api/', include(('conduit.apps.profiles.urls', 'profiles'), namespace='profiles'))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django==1.10.5
-django-cors-middleware==1.3.1
-django-extensions==1.7.1
-djangorestframework==3.4.4
-PyJWT==1.4.2
-six==1.10.0
+Django==3.1.2
+django-cors-middleware==1.5.0
+django-extensions==3.0.9
+djangorestframework==3.12.1
+PyJWT==1.7.1
+six==1.15.0


### PR DESCRIPTION
Update to run on python 3.8.6

Fixes: https://github.com/eclipse/che/issues/16183

related PRs: 
* https://github.com/eclipse/che-devfile-registry/pull/294
* https://github.com/eclipse/che-plugin-registry/pull/641
* https://github.com/che-samples/django-realworld-example-app/pull/1